### PR TITLE
Fix high score saving

### DIFF
--- a/scoreboard.py
+++ b/scoreboard.py
@@ -33,6 +33,7 @@ class Scoreboard(Turtle):
         self.score += 1
         if self.score > self.high_score:
             self.high_score = self.score
+            self.save_high_score()
         self.update_scoreboard()
 
     def reset(self):


### PR DESCRIPTION
## Summary
- ensure the high score is written to disk as soon as it's exceeded

## Testing
- `python - <<'PY'
from scoreboard import Scoreboard
PY` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_685bf54eff6483308bfdb31be8141b6c